### PR TITLE
Ansicon problems on Windows 7 64bit

### DIFF
--- a/AnsiCon/AnsiCon.nuspec
+++ b/AnsiCon/AnsiCon.nuspec
@@ -2,7 +2,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
     <metadata>
         <id>ansicon</id>
-        <version>1.5.0.2</version>
+        <version>1.5.3</version>
         <title>ANSICON</title>
         <authors>Jason Hood</authors>
         <owners>H. Alan Stevens</owners>

--- a/AnsiCon/tools/ChocolateyInstall.ps1
+++ b/AnsiCon/tools/ChocolateyInstall.ps1
@@ -1,6 +1,6 @@
 
 $packageName = 'ansicon'
-$url = 'https://github.com/downloads/adoxa/ansicon/ansi150.zip'
+$url = 'https://github.com/downloads/adoxa/ansicon/ansi153.zip'
 $chocTempDir = Join-Path $env:TEMP "chocolatey"
 $unzipLocation = Join-Path $chocTempDir "$packageName"
 $is64bit = (Get-WmiObject Win32_Processor).AddressWidth -eq 64


### PR DESCRIPTION
When running in Console, Ansicon constantly hung and made the system unusable. I upgraded locally to the latest version and it fixed the issue.
