### PR TITLE
Change chocolatey_bin_root to \bin

### DIFF
--- a/BinRoot/tools/ChocolateyInstall.ps1
+++ b/BinRoot/tools/ChocolateyInstall.ps1
@@ -1,4 +1,4 @@
 $packageName = 'BinRoot'
 
 ### Set the environment variable for the bin root to a default value if not already set ###
-if($env:chocolatey_bin_root -eq $null){[Environment]::SetEnvironmentVariable("chocolatey_bin_root", "bin", "User")}
+if($env:chocolatey_bin_root -eq $null){[Environment]::SetEnvironmentVariable("chocolatey_bin_root", "\bin", "User")}


### PR DESCRIPTION
This way, "\bin" ,it works on Windows 8 64-bit.

Using just "bin", without the  leading backslash, it fails in my case.
