### PR TITLE
updated Irfanview download URL, old one was not valid anymore

### DIFF
--- a/IrfanView/tools/ChocolateyInstall.ps1
+++ b/IrfanView/tools/ChocolateyInstall.ps1
@@ -17,7 +17,7 @@ $fileType = 'exe'
 
 $silentArgs = "/silent /folder=`"$irfanViewPath`" /desktop=0 /thunbs=0 /group=1 /allusers=0 /assoc=1"
 
-$url = 'http://www12.tucows.com/windows/files/iview437_setup.exe'
+$url = 'http://www.tucows.com/download/windows/files/iview437_setup.exe'
 
 write-host $silentArgs
 


### PR DESCRIPTION
as title says, currently the Irfanview package cannot be installed:
## Write-Error : IrfanView did not finish successfully. Boo to the chocolatey gods!
## [ERROR] Exception calling "GetResponse" with "0" argument(s): "The remote server returned an error: (503) Server Unavailable."

I changed the download URL from
http://www12.tucows.com/windows/files/iview437_setup.exe
to
http://www.tucows.com/download/windows/files/iview437_setup.exe
