### PR TITLE
Robustly upgrade, install, or uninstall ansicon machine-wide

### DIFF
--- a/AnsiCon/AnsiCon.nuspec
+++ b/AnsiCon/AnsiCon.nuspec
@@ -1,21 +1,16 @@
 <?xml version="1.0"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
-    <metadata>
-        <id>ansicon</id>
-        <version>1.6.6</version>
-        <title>ANSICON</title>
-        <authors>Jason Hood</authors>
-        <owners>H. Alan Stevens</owners>
-        <!--<licenseUrl></licenseUrl>-->
-        <projectUrl>https://github.com/adoxa/ansicon</projectUrl>
-        <!--<iconUrl></iconUrl>-->
-        <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <description>ANSICON provides ANSI escape sequences for Windows console programs.  It provides much the same functionality as `ANSI.SYS' does for MS-DOS.
-        </description>
-        <summary>ANSICON provides ANSI escape sequences for Windows console programs</summary>
-        <tags>console color ansi codes</tags>
-        <!--<dependencies>
-      <dependency id="" version="" />
-    </dependencies>-->
+  <metadata>
+    <id>ansicon</id>
+    <title>ANSICON</title>
+    <version>1.66</version>
+    <authors>Jason Hood</authors>
+    <owners>H. Alan Stevens</owners>
+    <projectUrl>https://github.com/adoxa/ansicon</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>ANSICON provides ANSI escape sequences for Windows console programs.  It provides much the same functionality as `ANSI.SYS' does for MS-DOS.
+    </description>
+    <summary>ANSICON provides ANSI escape sequences for Windows console programs</summary>
+    <tags>console color ansi codes</tags>
   </metadata>
 </package>

--- a/AnsiCon/tools/ChocolateyInstall.ps1
+++ b/AnsiCon/tools/ChocolateyInstall.ps1
@@ -1,6 +1,9 @@
 $id = "ansicon"
-$key = "HKCU:\Software\Microsoft\Command Processor"
 $url = "https://github.com/adoxa/ansicon/releases/download/v1.66/ansi166.zip"
+
+$user_key = "HKCU:\Software\Microsoft\Command Processor"
+$machine_key_32 = "HKLM:\Software\Microsoft\Command Processor"
+$machine_key_64 = "HKLM:\Software\Wow6432Node\Microsoft\Command Processor"
 
 $is64bit = Get-ProcessorBits 64
 $subfolder = @{$true="x64";$false="x86"}
@@ -14,42 +17,8 @@ Install-ChocolateyZipPackage $id $url $content
 
 New-Item $ignore -Type File -Force | Out-Null
 
-# ANSICON -i produces a Command Processor AutoRun property with these attributes
-#
-#   * at the beginning of the property
-#   * surrounded by parenthesis
-#   * separated by a single & (when there are existing commands)
-#   * without the file extension
-#
-# Example without existing commands:
-# 
-#   (if %ANSICON_VER%==^%ANSICON_VER^% "path\to\ansicon" -p)
-#
-# Example with existing commands:
-# 
-#   (if %ANSICON_VER%==^%ANSICON_VER^% "path\to\ansicon" -p)&<other-commands>
-#
-$statement = "(if %ANSICON_VER%==^%ANSICON_VER^% `"$ansicon`" -p)"
-$pattern = '(?<ansicon>\(if %ANSICON_VER%==\^%ANSICON_VER\^% ".*" -p\))'
+. (Join-Path $tools "ansicon.ps1")
 
-$autorun = (Get-ItemProperty -Path $key).AutoRun
-
-$autorun -match $pattern
-$match = $matches["ansicon"]
-
-Write-Debug "[ANSICON] Adding ANSICON to the Command Processor AutoRun registry: `"$autorun`""
-
-if(-not $autorun) {
-  $autorun = $statement
-}
-elseif($match) {
-  Write-Debug "[ANSICON] Replacing existing ANSICON command: `"$match`""
-  $autorun = $autorun -replace [regex]::Escape($match), $statement
-}
-else {
-  $autorun = $statement + "&" + $autorun
-}
-
-Write-Debug "[ANSICON] New AutoRun value: `"$autorun`""
-
-Set-ItemProperty -Path $key -Name "AutoRun" -Value $autorun -Type String
+Remove-AnsiconProperty -Key $user_key
+Set-AnsiconProperty -Key $machine_key_32 -Ansicon $ansicon
+Set-AnsiconProperty -Key $machine_key_64 -Ansicon $ansicon

--- a/AnsiCon/tools/ansicon.ps1
+++ b/AnsiCon/tools/ansicon.ps1
@@ -1,0 +1,64 @@
+# ANSICON -i produces a Command Processor AutoRun property with these attributes
+#
+#   * at the beginning of the property
+#   * surrounded by parenthesis
+#   * separated by a single & (when there are existing commands)
+#   * without the file extension
+#
+# Example without existing commands:
+# 
+#   (if %ANSICON_VER%==^%ANSICON_VER^% "path\to\ansicon" -p)
+#
+# Example with existing commands:
+# 
+#   (if %ANSICON_VER%==^%ANSICON_VER^% "path\to\ansicon" -p)&<other-commands>
+#
+$pattern = '(?<ansicon>\(if %ANSICON_VER%==\^%ANSICON_VER\^% ".*" -p\))'
+$pattern_greedy = '(?<ansicon>\(if %ANSICON_VER%==\^%ANSICON_VER\^% ".*" -p\)&*)'
+
+function Remove-AnsiconProperty($key) {
+  $autorun = (Get-ItemProperty -Path $key).AutoRun
+
+  Write-Debug "[ANSICON] Registry key: $key"
+  Write-Debug "[ANSICON] AutoRun property: $autorun"
+
+  if(-not $autorun) {
+    return
+  }
+
+  if(-not($autorun -match $pattern_greedy)) {
+    return
+  }
+
+  $match = $matches["ansicon"]
+  $autorun = $autorun -replace [regex]::Escape($match), ""
+
+  Write-Debug "[ANSICON] AutoRun property: $autorun"
+
+  Set-ItemProperty -Path $key -Name "AutoRun" -Value $autorun -Type String
+}
+
+function Set-AnsiconProperty($key, $ansicon) {
+  $statement = "(if %ANSICON_VER%==^%ANSICON_VER^% `"$ansicon`" -p)"
+
+  $autorun = (Get-ItemProperty -Path $key).AutoRun
+
+  Write-Debug "[ANSICON] Ansicon path: $ansicon"
+  Write-Debug "[ANSICON] Registry key: $key"
+  Write-Debug "[ANSICON] AutoRun property: $autorun"
+
+  if(-not $autorun) {
+    $autorun = $statement
+  }
+  elseif($autorun -match $pattern) {
+    $match = $matches["ansicon"]
+    $autorun = $autorun -replace [regex]::Escape($match), $statement
+  }
+  else {
+    $autorun = $statement + '&' + $autorun
+  }
+
+  Write-Debug "[ANSICON] AutoRun property: $autorun"
+
+  Set-ItemProperty -Path $key -Name "AutoRun" -Value $autorun -Type "String"
+}

--- a/AnsiCon/tools/chocolateyUninstall.ps1
+++ b/AnsiCon/tools/chocolateyUninstall.ps1
@@ -1,0 +1,11 @@
+$user_key = "HKCU:\Software\Microsoft\Command Processor"
+$machine_key_32 = "HKLM:\Software\Microsoft\Command Processor"
+$machine_key_64 = "HKLM:\Software\Wow6432Node\Microsoft\Command Processor"
+
+$tools = Split-Path $MyInvocation.MyCommand.Definition
+
+. (Join-Path $tools "ansicon.ps1")
+
+Remove-AnsiconProperty -Key $user_key
+Remove-AnsiconProperty -Key $machine_key_32
+Remove-AnsiconProperty -Key $machine_key_64


### PR DESCRIPTION
I hope you like where I'm going with this pull request... 

 * reduce complexity with regex matching, guard clauses, and functions
 * accurately model the ansicon autorun property
 * reliably update and even uninstall the autorun property

I don't know if you ever solved the problem of overwriting the ansicon files on upgrade or removing them on uninstall. I don't have an answer yet, but I wanted to get this in front of you. I think `cmd /D` might be the answer somehow... http://technet.microsoft.com/en-us/library/cc779439(v=WS.10).aspx

The first commit message actually has a ton of explanation in it: b3885b6940ad35b3ef27ad08bb5d3c314fad9cc9