### PR TITLE
Updated TortoiseGit to 1.8.12.0

### DIFF
--- a/TortoiseGit/TortoiseGit.nuspec
+++ b/TortoiseGit/TortoiseGit.nuspec
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd">
     <metadata>
         <id>TortoiseGit</id>
-        <version>1.8.10.0</version>
+        <version>1.8.12.0</version>
         <title>TortoiseGit</title>
         <authors>Sven Strickroth and Frank Li</authors>
         <owners>H. Alan Stevens,Matt Wrock,Pure Krome</owners>

--- a/TortoiseGit/tools/ChocolateyInstall.ps1
+++ b/TortoiseGit/tools/ChocolateyInstall.ps1
@@ -1,1 +1,1 @@
-Install-ChocolateyPackage 'TortoiseGit' 'MSI' '/QN /norestart REBOOT=ReallySuppress' 'http://download.tortoisegit.org/tgit/1.8.10.0/TortoiseGit-1.8.10.0-32bit.msi' 'http://download.tortoisegit.org/tgit/1.8.10.0/TortoiseGit-1.8.10.0-64bit.msi'
+﻿Install-ChocolateyPackage 'TortoiseGit' 'MSI' '/QN /norestart REBOOT=ReallySuppress' 'http://download.tortoisegit.org/tgit/1.8.12.0/TortoiseGit-1.8.12.0-32bit.msi' 'http://download.tortoisegit.org/tgit/1.8.12.0/TortoiseGit-1.8.12.0-64bit.msi'


### PR DESCRIPTION
Hi,

I just updated TortoiseGit to the latest 1.8.12.0.
`TortoiseGit.nuspec` is also in UTF-8 without BOM now so we follow the [Chocolatey Guideline](https://github.com/chocolatey/chocolatey/wiki/CreatePackages#character-encoding). That should explain the non-version related changes.

I've tested it on my own machine : Windows 7 x64. It worked just as before : it stopped `explorer.exe` (and `chrome.exe`) without rebooting.

Thanks for all the packages by the way !
