### PR TITLE
[Fixed] Growl bug of installtion

### DIFF
--- a/Growl/tools/ChocolateyInstall.ps1
+++ b/Growl/tools/ChocolateyInstall.ps1
@@ -16,7 +16,7 @@ try
     }
 
     $params = @{
-        packageName = $package;
+        packageName = 'growl';
         fileType = 'exe';
         silentArgs = '/c:"msiexec -i Growl_v2.0.msi /qn"'
         url = 'http://www.growlforwindows.com/gfw/d.ashx?f=GrowlInstaller.exe';


### PR DESCRIPTION
See [**comments**](https://chocolatey.org/packages/Growl) of package, many users can not install Growl package.

I have same error:

```perl
PS E:\Test\Growl> cinst growl -y --force
Chocolatey v0.10.3
Installing the following packages:
growl
By installing you accept licenses for the packages.

Growl v2.0.9.20130406 (forced) [Approved] - Possibly broken
growl package files install completed. Performing other installation steps.
WARNING: Write-ChocolateyFailure is deprecated and will be removed in v2. If you are the package maintainer, please use 'throw $_.Exception' instead.
ERROR: Cannot bind argument to parameter 'packageName' because it is an empty string.
The install of growl was NOT successful.
Error while running 'E:\Chocolatey\lib\Growl\tools\ChocolateyInstall.ps1'.
 See log for details.

Chocolatey installed 0/1 packages. 1 packages failed.
 See the log for details (E:\Chocolatey\logs\chocolatey.log).

Failures
 - growl (exited -1) - Error while running 'E:\Chocolatey\lib\Growl\tools\ChocolateyInstall.ps1'.
 See log for details.
```

I fixed that behavior, now Growl successfully installed for me:

```perl
PS E:\Test\Growl> choco pack
Chocolatey v0.10.3
Attempting to build package from 'Growl.nuspec'.
Successfully created package 'E:\Test\Growl\Growl.2.0.9.20130406.nupkg'
PS E:\Test\Growl> choco install Growl -s "$pwd" -f
Chocolatey v0.10.3
Installing the following packages:
Growl
By installing you accept licenses for the packages.

Growl v2.0.9.20130406 (forced)
growl package files install completed. Performing other installation steps.
The package Growl wants to run 'ChocolateyInstall.ps1'.
Note: If you don't run this script, the installation will fail.
Note: To confirm automatically next time, use '-y' or consider setting
 'allowGlobalConfirmation'. Run 'choco feature -h' for more details.
Do you want to run the script?([Y]es/[N]o/[P]rint): y

Downloading growl
  from 'http://www.growlforwindows.com/gfw/d.ashx?f=GrowlInstaller.exe'
Progress: 100% - Completed download of C:\Users\SashaChernykh\AppData\Local\Temp\chocolatey\Growl\2.0.9.20130406\GrowlInstaller.exe (2.18 MB).
Download of GrowlInstaller.exe (2.18 MB) completed.
Installing growl...
growl has been installed.
WARNING: Write-ChocolateySuccess is deprecated and will be removed in v2. If you are the maintainer, please remove it from your package file.
 The install of growl was successful.
  Software installed as 'exe', install location is likely default.

Chocolatey installed 1/1 packages. 0 packages failed.
 See the log for details (E:\Chocolatey\logs\chocolatey.log).
```

Thanks.

