### PR TITLE
Download installer from Github repository

### DIFF
--- a/Growl/Growl.nuspec
+++ b/Growl/Growl.nuspec
@@ -3,7 +3,7 @@
     <metadata>
         <id>Growl</id>
         <title>Growl For Windows</title>
-        <version>2.0.9.20130406</version>
+        <version>2.0.9.20191130</version>
         <authors>Brian Dunnington</authors>
         <owners>H. Alan Stevens,Ethan Brown,Patrick Wyatt</owners>
         <summary>Growl for Windows is a Windows-compatible version of Growl, a notification system for Mac OS X.</summary>

--- a/Growl/Growl.nuspec
+++ b/Growl/Growl.nuspec
@@ -3,19 +3,18 @@
     <metadata>
         <id>Growl</id>
         <title>Growl For Windows</title>
-        <version>2.0.9.20191130</version>
+        <version>2.0.9.20191201</version>
         <authors>Brian Dunnington</authors>
         <owners>H. Alan Stevens,Ethan Brown,Patrick Wyatt</owners>
         <summary>Growl for Windows is a Windows-compatible version of Growl, a notification system for Mac OS X.</summary>
         <description>Growl for Windows is a Windows-compatible version of Growl, a notification system for Mac OS X. Growl lets you know when things happen. Files finished downloading, friends came online, new email has arrived - Growl can let you know when any event occurs with a subtle notification. The rest of the time, Growl stays out of your way.
         | Please install with chocolatey (http://nuget.org/List/Packages/chocolatey).</description>
         <projectUrl>http://www.growlforwindows.com/</projectUrl>
-        <tags>growl chocolatey</tags>
+        <tags>growl notification notification-service</tags>
         <licenseUrl>http://www.opensource.org/licenses/bsd-license.php</licenseUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
         <iconUrl>https://github.com/webcoyote/ChocoPackages/raw/master/Growl/Growl.png</iconUrl>
-        <!--<dependencies>
-      <dependency id="" version="" />
-    </dependencies>-->
+        <projectSourceUrl>https://github.com/briandunnington/growl-for-windows</projectSourceUrl>
+        <packageSourceUrl>https://github.com/webcoyote/ChocoPackages/tree/master/Growl</packageSourceUrl>
   </metadata>
 </package>

--- a/Growl/Growl.nuspec
+++ b/Growl/Growl.nuspec
@@ -5,7 +5,7 @@
         <title>Growl For Windows</title>
         <version>2.0.9.20130406</version>
         <authors>Brian Dunnington</authors>
-        <owners>H. Alan Stevens,Ethan Brown</owners>
+        <owners>H. Alan Stevens,Ethan Brown,Patrick Wyatt</owners>
         <summary>Growl for Windows is a Windows-compatible version of Growl, a notification system for Mac OS X.</summary>
         <description>Growl for Windows is a Windows-compatible version of Growl, a notification system for Mac OS X. Growl lets you know when things happen. Files finished downloading, friends came online, new email has arrived - Growl can let you know when any event occurs with a subtle notification. The rest of the time, Growl stays out of your way.
         | Please install with chocolatey (http://nuget.org/List/Packages/chocolatey).</description>
@@ -13,7 +13,7 @@
         <tags>growl chocolatey</tags>
         <licenseUrl>http://www.opensource.org/licenses/bsd-license.php</licenseUrl>
         <requireLicenseAcceptance>false</requireLicenseAcceptance>
-        <iconUrl>https://github.com/alanstevens/ChocoPackages/raw/master/Growl/Growl.png</iconUrl>
+        <iconUrl>https://github.com/webcoyote/ChocoPackages/raw/master/Growl/Growl.png</iconUrl>
         <!--<dependencies>
       <dependency id="" version="" />
     </dependencies>-->

--- a/Growl/tools/ChocolateyInstall.ps1
+++ b/Growl/tools/ChocolateyInstall.ps1
@@ -1,33 +1,20 @@
-$packageName = 'Growl'
-
-try
+if ([Environment]::OSVersion.Version -gt '6.2')
 {
-    if ([Environment]::OSVersion.Version -gt '6.2')
+    $feature = @{FeatureName = 'NetFx3'; Online = $true}
+    $fxInstalled = Get-WindowsOptionalFeature @feature |
+        Select -ExpandProperty State
+
+    if ($fxInstalled -ne 'Enabled')
     {
-        $feature = @{FeatureName = 'NetFx3'; Online = $true}
-        $fxInstalled = Get-WindowsOptionalFeature @feature |
-            Select -ExpandProperty State
-
-        if ($fxInstalled -ne 'Enabled')
-        {
-            Write-Host 'Enabling .NET Framework 2.0 runtime...'
-            Enable-WindowsOptionalFeature @feature
-        }
+        Write-Host 'Enabling .NET Framework 2.0 runtime...'
+        Enable-WindowsOptionalFeature @feature
     }
-
-    $params = @{
-        packageName = $package;
-        fileType = 'exe';
-        silentArgs = '/c:"msiexec -i Growl_v2.0.msi /qn"'
-        url = 'http://www.growlforwindows.com/gfw/d.ashx?f=GrowlInstaller.exe';
-    }
-
-    Install-ChocolateyPackage @params
-
-    Write-ChocolateySuccess $packageName
 }
-catch
-{
-    Write-ChocolateyFailure $package "$($_.Exception.Message)"
-    throw
+
+$params = @{
+    packageName = "growl";
+    fileType = 'exe';
+    silentArgs = '/c:"msiexec -i Growl_v2.0.msi /qn"';
+    url = 'https://github.com/briandunnington/growl-for-windows/releases/download/final/GrowlInstaller.exe';
 }
+Install-ChocolateyPackage @params

--- a/Growl/tools/ChocolateyInstall.ps1
+++ b/Growl/tools/ChocolateyInstall.ps1
@@ -1,20 +1,9 @@
-if ([Environment]::OSVersion.Version -gt '6.2')
-{
-    $feature = @{FeatureName = 'NetFx3'; Online = $true}
-    $fxInstalled = Get-WindowsOptionalFeature @feature |
-        Select -ExpandProperty State
-
-    if ($fxInstalled -ne 'Enabled')
-    {
-        Write-Host 'Enabling .NET Framework 2.0 runtime...'
-        Enable-WindowsOptionalFeature @feature
-    }
-}
-
 $params = @{
     packageName = "growl";
     fileType = 'exe';
     silentArgs = '/c:"msiexec -i Growl_v2.0.msi /qn"';
     url = 'https://github.com/briandunnington/growl-for-windows/releases/download/final/GrowlInstaller.exe';
+    checksum = '663598d376d15eaea5d82d21abcaed36039d958eced0e085b7b9937f3e10b8da';
+    checksumType = 'sha256';
 }
 Install-ChocolateyPackage @params


### PR DESCRIPTION
Hello. I've created this PR to download the Growl installer from Brian Dunnington's Github repository instead of the www.growlforwindows.com, as the installer is no longer available.

I've tested this locally and it seems to work fine. Please let me know if you'd like me to make changes, otherwise can I request that you upload this to Chocolatey, or add me as a maintainer so I can? If you'd like to make me a maintainer, my handle on Chocolatey is webcoyote, same as for Github.

Thanks,

Pat
